### PR TITLE
chore(typo): fix typo in context/propagation/context.rs

### DIFF
--- a/src/context/propagation/context.rs
+++ b/src/context/propagation/context.rs
@@ -26,7 +26,7 @@ pub struct PropagationContext {
     /// It defines trace ID that previous span has. It expresses unique value of entire trace.
     pub parent_trace_id: String,
 
-    /// It defines segment ID that previos span has. It expresses unique value of entire trace.
+    /// It defines segment ID that previous span has. It expresses unique value of entire trace.
     pub parent_trace_segment_id: String,
 
     /// It defines parent span's span ID.
@@ -45,7 +45,7 @@ pub struct PropagationContext {
     pub destination_address: String,
 }
 
-/// PropagationContext carries the context which include trace infomation.
+/// PropagationContext carries the context which include trace information.
 /// In general, this context will be used if you create new TraceContext after received
 /// decoded context that should be packed in `sw8` header.
 impl PropagationContext {


### PR DESCRIPTION
issue : https://github.com/apache/skywalking/issues/9272

1. previos -> previous
https://github.com/apache/skywalking-rust/blob/5fded8e7cb936de4a6a3d6b689f9d22645466d2f/src/context/propagation/context.rs#L29

2. infomation - > information
https://github.com/apache/skywalking-rust/blob/5fded8e7cb936de4a6a3d6b689f9d22645466d2f/src/context/propagation/context.rs#L48

