### PR TITLE
Feature(tonic-build): set tonic-build.build_server(false), do not build Server code.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,11 +15,9 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
-        .build_server(false)
-        .compile(
-            &["./skywalking-data-collect-protocol/language-agent/Tracing.proto"],
-            &["./skywalking-data-collect-protocol"],
-        )?;
+    tonic_build::configure().build_server(false).compile(
+        &["./skywalking-data-collect-protocol/language-agent/Tracing.proto"],
+        &["./skywalking-data-collect-protocol"],
+    )?;
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -15,9 +15,11 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile(
-        &["./skywalking-data-collect-protocol/language-agent/Tracing.proto"],
-        &["./skywalking-data-collect-protocol"],
-    )?;
+    tonic_build::configure()
+        .build_server(false)
+        .compile(
+            &["./skywalking-data-collect-protocol/language-agent/Tracing.proto"],
+            &["./skywalking-data-collect-protocol"],
+        )?;
     Ok(())
 }


### PR DESCRIPTION
issue https://github.com/apache/skywalking/issues/9271

the `trace_segment_report_service_server::TraceSegmentReportServiceServer` built by tonic-build is redundant now, and adding `.build_server(false)` can reduce the generation of this code.