### PR TITLE
Rename crate name skywalking_rust to skywalking?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 #
 
 [package]
-name = "skywalking_rust"
+name = "skywalking"
 version = "0.1.0"
 authors = ["Apache SkyWalking Developers (dev@skywalking.apache.org)"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "skywalking"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Apache SkyWalking Developers (dev@skywalking.apache.org)"]
 edition = "2021"
 description = "Apache SkyWalking Rust Agent"

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ context after the span finished.
 # Example
 
 ```rust
-use skywalking_rust::context::trace_context::TracingContext;
-use skywalking_rust::reporter::grpc::Reporter;
+use skywalking::context::trace_context::TracingContext;
+use skywalking::reporter::grpc::Reporter;
 use tokio;
 
 async fn handle_request(reporter: ContextReporter) {

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ async fn main() {
 ```
 
 # How to compile?
-If you have `skywalking-rust-(VERSION).crate`, you can unpack it with the way as follows:
+If you have `skywalking-(VERSION).crate`, you can unpack it with the way as follows:
 
 ```
-tar -xvzf skywalking-rust-(VERSION).crate
+tar -xvzf skywalking-(VERSION).crate
 ```
 
 Using `cargo build` generates a library. If you'd like to verify the behavior, we recommend to use `cargo run --example simple_trace_report`

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hyper",
  "skywalking",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "base64",

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -184,7 +184,7 @@ name = "e2e"
 version = "0.1.0"
 dependencies = [
  "hyper",
- "skywalking_rust",
+ "skywalking",
  "structopt",
  "tokio",
 ]
@@ -777,7 +777,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "skywalking_rust"
+name = "skywalking"
 version = "0.1.0"
 dependencies = [
  "async-stream",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-skywalking_rust = { path = ".." }
+skywalking = { path = ".." }
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 structopt = "0.3"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -17,7 +17,7 @@
 #
 [package]
 name = "e2e"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Shikugawa <Shikugawa@gmail.com>"]
 edition = "2021"
 publish = false

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -18,11 +18,11 @@
 use hyper::client::HttpConnector;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client, Method, Request, Response, Server, StatusCode};
-use skywalking_rust::context::propagation::context::SKYWALKING_HTTP_CONTEXT_HEADER_KEY;
-use skywalking_rust::context::propagation::decoder::decode_propagation;
-use skywalking_rust::context::propagation::encoder::encode_propagation;
-use skywalking_rust::context::trace_context::TracingContext;
-use skywalking_rust::reporter::grpc::Reporter;
+use skywalking::context::propagation::context::SKYWALKING_HTTP_CONTEXT_HEADER_KEY;
+use skywalking::context::propagation::decoder::decode_propagation;
+use skywalking::context::propagation::encoder::encode_propagation;
+use skywalking::context::trace_context::TracingContext;
+use skywalking::reporter::grpc::Reporter;
 use std::convert::Infallible;
 use std::error::Error;
 use std::net::SocketAddr;

--- a/examples/simple_trace_report.rs
+++ b/examples/simple_trace_report.rs
@@ -17,8 +17,8 @@
 //
 use std::error::Error;
 
-use skywalking_rust::context::trace_context::TracingContext;
-use skywalking_rust::reporter::grpc::Reporter;
+use skywalking::context::trace_context::TracingContext;
+use skywalking::reporter::grpc::Reporter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/context/trace_context.rs
+++ b/src/context/trace_context.rs
@@ -34,7 +34,7 @@ use super::system_time::UnixTimeStampFetcher;
 /// # Example
 ///
 /// ```
-/// use skywalking_rust::context::trace_context::TracingContext;
+/// use skywalking::context::trace_context::TracingContext;
 ///
 /// async fn handle_request() {
 ///     let mut ctx = TracingContext::default("svc", "ins");
@@ -206,7 +206,7 @@ impl TracingContext {
 
     /// Generate a new trace context using the propagated context.
     /// They should be propagated on `sw8` header in HTTP request with encoded form.
-    /// You can retrieve decoded context with `skywalking_rust::context::propagation::encoder::encode_propagation`
+    /// You can retrieve decoded context with `skywalking::context::propagation::encoder::encode_propagation`
     pub fn from_propagation_context(
         service_name: &str,
         instance_name: &str,

--- a/src/reporter/grpc.rs
+++ b/src/reporter/grpc.rs
@@ -52,8 +52,8 @@ impl Reporter {
     ///
     /// use tokio;
     ///
-    /// use skywalking_rust::context::trace_context::TracingContext;
-    /// use skywalking_rust::reporter::grpc::Reporter;
+    /// use skywalking::context::trace_context::TracingContext;
+    /// use skywalking::reporter::grpc::Reporter;
     ///
     /// #[tokio::main]
     /// async fn main () -> Result<(), Box<dyn Error>> {

--- a/tests/propagation.rs
+++ b/tests/propagation.rs
@@ -15,11 +15,11 @@
 //
 
 #![allow(unused_imports)]
-use skywalking_rust::common::time::TimeFetcher;
-use skywalking_rust::context::propagation::context::PropagationContext;
-use skywalking_rust::context::propagation::decoder::decode_propagation;
-use skywalking_rust::context::propagation::encoder::encode_propagation;
-use skywalking_rust::context::trace_context::TracingContext;
+use skywalking::common::time::TimeFetcher;
+use skywalking::context::propagation::context::PropagationContext;
+use skywalking::context::propagation::decoder::decode_propagation;
+use skywalking::context::propagation::encoder::encode_propagation;
+use skywalking::context::trace_context::TracingContext;
 use std::sync::Arc;
 
 struct MockTimeFetcher {}

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -17,12 +17,12 @@
 #![allow(unused_imports)]
 
 use prost::Message;
-use skywalking_rust::common::time::TimeFetcher;
-use skywalking_rust::context::propagation::context::PropagationContext;
-use skywalking_rust::context::propagation::decoder::decode_propagation;
-use skywalking_rust::context::propagation::encoder::encode_propagation;
-use skywalking_rust::context::trace_context::TracingContext;
-use skywalking_rust::skywalking_proto::v3::{
+use skywalking::common::time::TimeFetcher;
+use skywalking::context::propagation::context::PropagationContext;
+use skywalking::context::propagation::decoder::decode_propagation;
+use skywalking::context::propagation::encoder::encode_propagation;
+use skywalking::context::trace_context::TracingContext;
+use skywalking::skywalking_proto::v3::{
     KeyStringValuePair, Log, RefType, SegmentObject, SegmentReference, SpanLayer, SpanObject,
     SpanType,
 };


### PR DESCRIPTION
The suffix `_rust` is not necessary, and using the crate name `skywalking` can prevent fraudulent use by third parties.