### PR TITLE
Switch to use nightly rustfmt.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --component rustfmt
+        run: rustup toolchain install nightly --component rustfmt
       - name: Run format
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
   check-and-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly --component rustfmt
+        run: rustup toolchain install nightly-2022-07-30 --component rustfmt
       - name: Run format
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +nightly-2022-07-30 fmt --all -- --check
 
   check-and-test:
     strategy:

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+format_code_in_doc_comments = true
+format_macro_bodies = true
+format_macro_matchers = true
+format_strings = true
+imports_granularity = "Crate"
+merge_derives = true
+newline_style = "Unix"
+normalize_comments = true
+reorder_impl_items = true
+use_field_init_shorthand = true
+wrap_comments = true

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -15,18 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-use hyper::client::HttpConnector;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Client, Method, Request, Response, Server, StatusCode};
-use skywalking::context::propagation::context::SKYWALKING_HTTP_CONTEXT_HEADER_KEY;
-use skywalking::context::propagation::decoder::decode_propagation;
-use skywalking::context::propagation::encoder::encode_propagation;
-use skywalking::context::tracer::{self, Tracer};
-use skywalking::reporter::grpc::GrpcReporter;
-use std::convert::Infallible;
-use std::error::Error;
-use std::future;
-use std::net::SocketAddr;
+use hyper::{
+    client::HttpConnector,
+    service::{make_service_fn, service_fn},
+    Body, Client, Method, Request, Response, Server, StatusCode,
+};
+use skywalking::{
+    context::{
+        propagation::{
+            context::SKYWALKING_HTTP_CONTEXT_HEADER_KEY, decoder::decode_propagation,
+            encoder::encode_propagation,
+        },
+        tracer::{self, Tracer},
+    },
+    reporter::grpc::GrpcReporter,
+};
+use std::{convert::Infallible, error::Error, future, net::SocketAddr};
 use structopt::StructOpt;
 
 static NOT_FOUND_MSG: &str = "not found";

--- a/examples/simple_trace_report.rs
+++ b/examples/simple_trace_report.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-use skywalking::context::tracer::Tracer;
-use skywalking::reporter::grpc::GrpcReporter;
+use skywalking::{context::tracer::Tracer, reporter::grpc::GrpcReporter};
 use std::error::Error;
 use tokio::signal;
 

--- a/src/context/propagation/context.rs
+++ b/src/context/propagation/context.rs
@@ -23,10 +23,12 @@ pub struct PropagationContext {
     /// OAP server and can be analyzed.
     pub do_sample: bool,
 
-    /// It defines trace ID that previous span has. It expresses unique value of entire trace.
+    /// It defines trace ID that previous span has. It expresses unique value of
+    /// entire trace.
     pub parent_trace_id: String,
 
-    /// It defines segment ID that previous span has. It expresses unique value of entire trace.
+    /// It defines segment ID that previous span has. It expresses unique value
+    /// of entire trace.
     pub parent_trace_segment_id: String,
 
     /// It defines parent span's span ID.
@@ -41,13 +43,14 @@ pub struct PropagationContext {
     /// An endpoint name that parent requested to.
     pub destination_endpoint: String,
 
-    /// An address that parent requested to. It can be authority or network address.
+    /// An address that parent requested to. It can be authority or network
+    /// address.
     pub destination_address: String,
 }
 
 /// PropagationContext carries the context which include trace information.
-/// In general, this context will be used if you create new TraceContext after received
-/// decoded context that should be packed in `sw8` header.
+/// In general, this context will be used if you create new TraceContext after
+/// received decoded context that should be packed in `sw8` header.
 impl PropagationContext {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/src/context/propagation/encoder.rs
+++ b/src/context/propagation/encoder.rs
@@ -17,8 +17,9 @@
 use crate::context::trace_context::TracingContext;
 use base64::encode;
 
-/// Encode TracingContext to carry current trace info to the destination of RPC call.
-/// In general, the output of this function will be packed in `sw8` header in HTTP call.
+/// Encode TracingContext to carry current trace info to the destination of RPC
+/// call. In general, the output of this function will be packed in `sw8` header
+/// in HTTP call.
 pub fn encode_propagation(context: &TracingContext, endpoint: &str, address: &str) -> String {
     format!(
         "1-{}-{}-{}-{}-{}-{}-{}",

--- a/src/context/span.rs
+++ b/src/context/span.rs
@@ -118,8 +118,9 @@ impl Span {
         self.context.upgrade().expect("Context has dropped")
     }
 
-    // Notice: Perhaps in the future, `RwLock` can be used instead of `Mutex`, so `with_*` can be nested.
-    // (Although I can't find the meaning of such use at present.)
+    // Notice: Perhaps in the future, `RwLock` can be used instead of `Mutex`, so
+    // `with_*` can be nested. (Although I can't find the meaning of such use at
+    // present.)
     pub fn with_span_object<T>(&self, f: impl FnOnce(&SpanObject) -> T) -> T {
         self.upgrade_context()
             .with_active_span_stack(|stack| f(&stack[self.index]))

--- a/src/context/trace_context.rs
+++ b/src/context/trace_context.rs
@@ -20,9 +20,8 @@ use super::{
     tracer::{Tracer, WeakTracer},
 };
 use crate::{
-    common::random_generator::RandomGenerator, context::propagation::context::PropagationContext,
-};
-use crate::{
+    common::random_generator::RandomGenerator,
+    context::propagation::context::PropagationContext,
     error::LOCK_MSG,
     skywalking_proto::v3::{
         RefType, SegmentObject, SegmentReference, SpanLayer, SpanObject, SpanType,
@@ -93,8 +92,9 @@ impl TracingContext {
     }
 
     /// Generate a new trace context using the propagated context.
-    /// They should be propagated on `sw8` header in HTTP request with encoded form.
-    /// You can retrieve decoded context with `skywalking::context::propagation::encoder::encode_propagation`
+    /// They should be propagated on `sw8` header in HTTP request with encoded
+    /// form. You can retrieve decoded context with
+    /// `skywalking::context::propagation::encoder::encode_propagation`
     pub(crate) fn from_propagation_context(
         service_name: impl ToString,
         instance_name: impl ToString,
@@ -205,8 +205,8 @@ impl TracingContext {
     }
 
     /// Create a new entry span, which is an initiator of collection of spans.
-    /// This should be called by invocation of the function which is triggered by
-    /// external service.
+    /// This should be called by invocation of the function which is triggered
+    /// by external service.
     pub fn create_entry_span(&mut self, operation_name: &str) -> Span {
         let mut span = Span::new_obj(
             self.inc_next_span_id(),
@@ -235,8 +235,8 @@ impl TracingContext {
         Span::new(index, self.downgrade())
     }
 
-    /// Create a new exit span, which will be created when tracing context will generate
-    /// new span for function invocation.
+    /// Create a new exit span, which will be created when tracing context will
+    /// generate new span for function invocation.
     /// Currently, this SDK supports RPC call. So we must set `remote_peer`.
     ///
     /// # Panics

--- a/src/context/tracer.rs
+++ b/src/context/tracer.rs
@@ -16,21 +16,25 @@
 
 use super::propagation::context::PropagationContext;
 use crate::{
-    context::trace_context::TracingContext, reporter::DynReporter, reporter::Reporter,
+    context::trace_context::TracingContext,
+    reporter::{DynReporter, Reporter},
     skywalking_proto::v3::SegmentObject,
 };
-use std::error::Error;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Weak;
-use std::task::{Context, Poll};
-use std::{collections::LinkedList, sync::Arc};
-use tokio::sync::OnceCell;
+use std::{
+    collections::LinkedList,
+    error::Error,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Weak,
+    },
+    task::{Context, Poll},
+};
 use tokio::{
     sync::{
         mpsc::{self},
-        Mutex,
+        Mutex, OnceCell,
     },
     task::JoinHandle,
 };

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -18,8 +18,7 @@ pub mod grpc;
 pub mod log;
 
 use crate::skywalking_proto::v3::SegmentObject;
-use std::collections::LinkedList;
-use std::{error::Error, result::Result};
+use std::{collections::LinkedList, error::Error, result::Result};
 use tonic::async_trait;
 
 pub(crate) type DynReporter = dyn Reporter + Send + Sync + 'static;

--- a/tests/propagation.rs
+++ b/tests/propagation.rs
@@ -15,12 +15,16 @@
 //
 
 #![allow(unused_imports)]
-use skywalking::context::propagation::context::PropagationContext;
-use skywalking::context::propagation::decoder::decode_propagation;
-use skywalking::context::propagation::encoder::encode_propagation;
-use skywalking::context::trace_context::TracingContext;
-use skywalking::context::tracer::Tracer;
-use skywalking::reporter::log::LogReporter;
+use skywalking::{
+    context::{
+        propagation::{
+            context::PropagationContext, decoder::decode_propagation, encoder::encode_propagation,
+        },
+        trace_context::TracingContext,
+        tracer::Tracer,
+    },
+    reporter::log::LogReporter,
+};
 use std::sync::Arc;
 
 #[test]

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -15,19 +15,24 @@
 //
 
 use prost::Message;
-use skywalking::context::propagation::decoder::decode_propagation;
-use skywalking::context::propagation::encoder::encode_propagation;
-use skywalking::context::tracer::Tracer;
-use skywalking::reporter::log::LogReporter;
-use skywalking::reporter::Reporter;
-use skywalking::skywalking_proto::v3::{
-    KeyStringValuePair, Log, RefType, SegmentObject, SegmentReference, SpanLayer, SpanObject,
-    SpanType,
+use skywalking::{
+    context::{
+        propagation::{decoder::decode_propagation, encoder::encode_propagation},
+        tracer::Tracer,
+    },
+    reporter::{log::LogReporter, Reporter},
+    skywalking_proto::v3::{
+        KeyStringValuePair, Log, RefType, SegmentObject, SegmentReference, SpanLayer, SpanObject,
+        SpanType,
+    },
 };
-use std::collections::LinkedList;
-use std::error::Error;
-use std::sync::{Arc, Mutex};
-use std::{future, thread};
+use std::{
+    collections::LinkedList,
+    error::Error,
+    future,
+    sync::{Arc, Mutex},
+    thread,
+};
 
 /// Serialize from A should equal Serialize from B
 #[allow(dead_code)]


### PR DESCRIPTION
The stable `rustfmt` is too weak, so switch to use the nightly `rustfmt` and add some useful options in `.rustfmt.toml`, such as merge imports and format comments.