### PR TITLE
Change Span to refer to SpanStack, rather than TracingContext.

### DIFF
--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -112,8 +112,8 @@ async fn handle_pong(_req: Request<Body>) -> Result<Response<Body>, Infallible> 
             .unwrap(),
     )
     .unwrap();
-    let mut context = tracer::create_trace_context_from_propagation(ctx);
-    let _span = context.create_entry_span("/pong");
+    let mut context = tracer::create_trace_context();
+    let _span = context.create_entry_span_with_propagation("/pong", &ctx);
     Ok(Response::new(Body::from("hoge")))
 }
 

--- a/src/context/span.rs
+++ b/src/context/span.rs
@@ -14,6 +14,10 @@
 // limitations under the License.
 //
 
+use super::{
+    system_time::{fetch_time, TimePeriod},
+    trace_context::SpanStack,
+};
 use crate::{
     error::LOCK_MSG,
     skywalking_proto::v3::{SpanLayer, SpanObject, SpanType},
@@ -21,10 +25,6 @@ use crate::{
 use std::{
     fmt::Formatter,
     sync::{Arc, Weak},
-};
-use super::{
-    system_time::{fetch_time, TimePeriod},
-    trace_context::SpanStack,
 };
 
 /// Span is a concept that represents trace information for a single RPC.

--- a/src/context/tracer.rs
+++ b/src/context/tracer.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-use super::propagation::context::PropagationContext;
 use crate::{
     context::trace_context::TracingContext,
     reporter::{DynReporter, Reporter},
@@ -57,11 +56,6 @@ pub fn global_tracer() -> &'static Tracer {
 /// Create trace conetxt by global tracer.
 pub fn create_trace_context() -> TracingContext {
     global_tracer().create_trace_context()
-}
-
-/// Create trace conetxt from propagation by global tracer.
-pub fn create_trace_context_from_propagation(context: PropagationContext) -> TracingContext {
-    global_tracer().create_trace_context_from_propagation(context)
 }
 
 /// Start to reporting by global tracer, quit when shutdown_signal received.
@@ -198,19 +192,6 @@ impl Tracer {
         TracingContext::new(
             &self.inner.service_name,
             &self.inner.instance_name,
-            self.downgrade(),
-        )
-    }
-
-    /// Create trace conetxt from propagation.
-    pub fn create_trace_context_from_propagation(
-        &self,
-        context: PropagationContext,
-    ) -> TracingContext {
-        TracingContext::from_propagation_context(
-            &self.inner.service_name,
-            &self.inner.instance_name,
-            context,
             self.downgrade(),
         )
     }

--- a/src/context/tracer.rs
+++ b/src/context/tracer.rs
@@ -184,7 +184,7 @@ impl Tracer {
         &self.inner.instance_name
     }
 
-    /// Set the reporter, only 
+    /// Set the reporter, only valid if [`Tracer::reporting`] not started.
     pub fn set_reporter(&self, reporter: impl Reporter + Send + Sync + 'static) {
         if !self.inner.is_reporting.load(Ordering::Relaxed) {
             if let Ok(mut lock) = self.inner.reporter.try_lock() {

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -203,7 +203,8 @@ async fn create_span_from_context() {
     MockReporter::with(
         |reporter| {
             let tracer = Tracer::new("service2", "instance2", reporter);
-            let _context = tracer.create_trace_context_from_propagation(prop);
+            let mut context = tracer.create_trace_context();
+            let _span = context.create_entry_span_with_propagation("operation_name", &prop);
             tracer
         },
         |segment| {
@@ -233,9 +234,9 @@ fn crossprocess_test() {
             let dec_prop = decode_propagation(&enc_prop).unwrap();
 
             let tracer = Tracer::new("service2", "instance2", LogReporter::new());
-            let mut context2 = tracer.create_trace_context_from_propagation(dec_prop);
+            let mut context2 = tracer.create_trace_context();
 
-            let span3 = context2.create_entry_span("op2");
+            let span3 = context2.create_entry_span_with_propagation("op2", &dec_prop);
             drop(span3);
 
             let span3 = context2.last_span().unwrap();

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -115,9 +115,7 @@ async fn create_span() {
                         logs: Vec::<Log>::new(),
                         skip_analysis: false,
                     };
-                    context.with_spans(|spans| {
-                        assert_eq!(spans.last(), Some(&span3_expected));
-                    });
+                    assert_eq!(context.last_span(), Some(span3_expected));
                 }
 
                 {
@@ -143,9 +141,7 @@ async fn create_span() {
                             logs: Vec::<Log>::new(),
                             skip_analysis: false,
                         };
-                        context.with_spans(|spans| {
-                            assert_eq!(spans.last(), Some(&span5_expected));
-                        });
+                        assert_eq!(context.last_span(), Some(span5_expected));
                     }
                 }
 
@@ -167,9 +163,7 @@ async fn create_span() {
                     logs: expected_log,
                     skip_analysis: false,
                 };
-                context.with_spans(|spans| {
-                    assert_eq!(spans.last(), Some(&span1_expected));
-                });
+                assert_eq!(context.last_span(), Some(span1_expected));
             }
 
             tracer
@@ -244,25 +238,24 @@ fn crossprocess_test() {
             let span3 = context2.create_entry_span("op2");
             drop(span3);
 
-            context2.with_spans(|spans| {
-                let span3 = spans.last().unwrap();
-                assert_eq!(span3.span_id, 0);
-                assert_eq!(span3.parent_span_id, -1);
-                assert_eq!(span3.refs.len(), 1);
+            let span3 = context2.last_span().unwrap();
 
-                let expected_ref = SegmentReference {
-                    ref_type: RefType::CrossProcess as i32,
-                    trace_id: context2.trace_id().to_owned(),
-                    parent_trace_segment_id: context1.trace_segment_id().to_owned(),
-                    parent_span_id: 1,
-                    parent_service: context1.service().to_owned(),
-                    parent_service_instance: context1.service_instance().to_owned(),
-                    parent_endpoint: "endpoint".to_string(),
-                    network_address_used_at_peer: "address".to_string(),
-                };
+            assert_eq!(span3.span_id, 0);
+            assert_eq!(span3.parent_span_id, -1);
+            assert_eq!(span3.refs.len(), 1);
 
-                check_serialize_equivalent(&expected_ref, &span3.refs[0]);
-            });
+            let expected_ref = SegmentReference {
+                ref_type: RefType::CrossProcess as i32,
+                trace_id: context2.trace_id().to_owned(),
+                parent_trace_segment_id: context1.trace_segment_id().to_owned(),
+                parent_span_id: 1,
+                parent_service: context1.service().to_owned(),
+                parent_service_instance: context1.service_instance().to_owned(),
+                parent_endpoint: "endpoint".to_string(),
+                network_address_used_at_peer: "address".to_string(),
+            };
+
+            check_serialize_equivalent(&expected_ref, &span3.refs[0]);
         }
     }
 }


### PR DESCRIPTION
In order to improve the performance of `TracingContext`, reduce the usage of Arc and Lock.