### PR TITLE
Add feature vendored, to auto build protoc.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
       matrix:
         features:
           - ""
+          - "--features vendored"
           - "--all-features"
     runs-on: ubuntu-20.04
     steps:
@@ -83,6 +84,7 @@ jobs:
           submodules: 'recursive'
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler=3.6.1.3-2ubuntu5
+        if: ${{ matrix.features != '--features vendored' }}
       - name: Install Rust toolchain
         run: rustup toolchain install stable --component clippy
       - name: Run check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ homepage = "https://skywalking.apache.org/"
 repository = "https://github.com/apache/skywalking-rust"
 
 [features]
+vendored = ["protobuf-src"]
 mock = []  # For internal integration testing only, do not use.
 
 [dependencies]
@@ -52,6 +53,7 @@ tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 
 [build-dependencies]
+protobuf-src = { version = "1.0.5", optional = true }
 tonic-build = "0.8.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ Using `cargo build` generates a library. If you'd like to verify the behavior, w
 use `cargo run --example simple_trace_report`
 which outputs executable, then run it.
 
+## NOTICE
+
+This crate automatically generates protobuf related code, which requires `protoc` before compile.
+
+Please choose one of the ways to install `protoc`.
+
+1. Using your OS package manager.
+
+   For Debian-base system:
+
+   ```shell
+   sudo apt install protobuf-compiler
+   ```
+
+   For MacOS:
+
+   ```shell
+   brew install protobuf
+   ```
+
+2. Auto compile `protoc` in the crate build script, just by adding the feature `vendored` in the `Cargo.toml`:
+
+   ```shell
+   cargo add skywalking --features vendored
+   ```
+
+3. Build from [source](https://github.com/protocolbuffers/protobuf). If `protc` isn't install inside $PATH, the env value `PROTOC` should be set.
+
+   ```shell
+   PROTOC=/the/path/of/protoc
+   ```
+
+For details, please refer to [prost-build:sourcing-protoc](https://docs.rs/prost-build/latest/prost_build/index.html#sourcing-protoc).
+
 # Release
 
 The SkyWalking committer(PMC included) could follow [this doc](Release-guide.md) to release an official version.

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,9 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "vendored")]
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     tonic_build::configure()
         .build_server(false)
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")


### PR DESCRIPTION
1. Add feature vendored, to auto build protoc.
2. Update document `How to compile?`.
3. The new optional crate `protobuf-src` under Apache-2.0 license.