### PR TITLE
Fix trace id is not transmitted.

### DIFF
--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -231,6 +231,7 @@ impl TracingContext {
         propagation: &PropagationContext,
     ) -> Span {
         let mut span = self.create_entry_span(operation_name);
+        self.trace_id = propagation.parent_trace_id.clone();
         span.with_span_object_mut(|span| {
             span.refs.push(SegmentReference {
                 ref_type: RefType::CrossProcess as i32,


### PR DESCRIPTION
In cross process scenes, the trace id is not transmitted, by mistake in the previous modification (https://github.com/apache/skywalking-rust/pull/39#issuecomment-1202186488).

The e2e is not coverd, because it dost not record trace id field.