### PR TITLE
Obtain Span object without intermediary.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install Cargo nightly
-        run: rustup toolchain install nightly
+        run: rustup toolchain install nightly-2023-05-19
       - name: Cargo minimal versions
-        run: cargo +nightly -Z minimal-versions generate-lockfile
+        run: cargo +nightly-2023-05-19 -Z minimal-versions generate-lockfile
       - name: Check License Header
         uses: apache/skywalking-eyes/header/@d299844e334855087f18ae1fe3c81ae8d22bc282
         with:
@@ -79,9 +79,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly-2022-07-30 --component rustfmt
+        run: rustup toolchain install nightly-2023-05-19 --component rustfmt
       - name: Run format
-        run: cargo +nightly-2022-07-30 fmt --all -- --check
+        run: cargo +nightly-2023-05-19 fmt --all -- --check
 
   check-and-test:
     strategy:
@@ -118,6 +118,6 @@ jobs:
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly-2022-07-30
+        run: rustup toolchain install nightly-2023-05-19
       - name: Run docs
-        run: cargo +nightly-2022-07-30 rustdoc --release --all-features -- --cfg docsrs
+        run: cargo +nightly-2023-05-19 rustdoc --release --all-features -- --cfg docsrs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler=3.6.1.3-2ubuntu5
+        run: sudo apt-get install -y protobuf-compiler
         if: ${{ matrix.features != '--features vendored' }}
       - name: Install Rust toolchain
         run: rustup toolchain install 1.63.0 --component clippy
@@ -116,7 +116,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler=3.6.1.3-2ubuntu5
+        run: sudo apt-get install -y protobuf-compiler
       - name: Install Rust toolchain
         run: rustup toolchain install nightly-2022-07-30
       - name: Run docs

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           submodules: true
       - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler=3.6.1.3-2ubuntu5
+        run: sudo apt-get install -y protobuf-compiler
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ description = "Apache SkyWalking Rust Agent"
 license = "Apache-2.0"
 homepage = "https://skywalking.apache.org/"
 repository = "https://github.com/apache/skywalking-rust"
-rust-version = "1.59"
+rust-version = "1.65"
 
 [features]
 management = ["hostname", "systemstat"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 [toolchain]
-channel = "1.63.0"
+channel = "1.65"
 components = ["rustfmt", "clippy"]
+

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -198,6 +198,15 @@ impl TracingContext {
         span_id
     }
 
+    /// Clone the last finalized span.
+    #[doc(hidden)]
+    pub fn last_span(&self) -> Option<SpanObject> {
+        RwLockReadGuard::try_map(self.span_stack.finalized(), |spans| spans.last())
+            .ok()
+            .as_deref()
+            .cloned()
+    }
+
     fn spans_mut(&mut self) -> RwLockWriteGuard<'_, Vec<SpanObject>> {
         self.span_stack.finalized.try_write().expect(LOCK_MSG)
     }

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -114,7 +114,7 @@ async fn create_span() {
                         logs: Vec::<Log>::new(),
                         skip_analysis: false,
                     };
-                    assert_eq!(context.last_span().as_deref(), Some(&span3_expected));
+                    assert_eq!(context.last_span(), Some(span3_expected));
                 }
 
                 {
@@ -140,7 +140,7 @@ async fn create_span() {
                             logs: Vec::<Log>::new(),
                             skip_analysis: false,
                         };
-                        assert_eq!(context.last_span().as_deref(), Some(&span5_expected));
+                        assert_eq!(context.last_span(), Some(span5_expected));
                     }
                 }
 
@@ -162,7 +162,7 @@ async fn create_span() {
                     logs: expected_log,
                     skip_analysis: false,
                 };
-                assert_eq!(context.last_span().as_deref(), Some(&span1_expected));
+                assert_eq!(context.last_span(), Some(span1_expected));
             }
 
             tracer


### PR DESCRIPTION
1. Previously, `SpanObjectRef` and `SpanObjectMut` were used to indirectly modify `SpanObject` hold by `Span` and `SpanStack`.

   But now I feel that there are many shortcomings, mainly due to Rust's ownership mechanism.

   Now that I've figured it out, through redundancy `span_id` and `segment_reference` to give `Span` ownership of `SpanObject`.

2. Upgrade MSVR (Minimum supported version of Rust) because dependencies breaks it .