### PR TITLE
Add kafka reporter.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,7 @@ jobs:
           - ""
           - "--features management"
           - "--features vendored"
+          - "--features kafka-reporter"
           - "--all-features"
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,4 +41,4 @@ jobs:
           pip3 install -r requirements.txt
           python3 e2e/run_e2e.py --expected_file=e2e/data/expected_context.yaml --max_retry_times=3 --target_path=/ping
           echo "run e2e-kafka"
-          docker-compose -f docker-compose.e2e.yml exec producer /build/target/release/e2e-kafka
+          docker-compose -f docker-compose.e2e.yml exec -T producer /build/target/release/e2e-kafka

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,3 +40,4 @@ jobs:
           pip3 install setuptools
           pip3 install -r requirements.txt
           python3 e2e/run_e2e.py --expected_file=e2e/data/expected_context.yaml --max_retry_times=3 --target_path=/ping
+          cargo test -p e2e --release -- --nocapture

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,5 +40,5 @@ jobs:
           pip3 install setuptools
           pip3 install -r requirements.txt
           python3 e2e/run_e2e.py --expected_file=e2e/data/expected_context.yaml --max_retry_times=3 --target_path=/ping
-          echo "run e2e-kafka"
+          docker-compose -f docker-compose.e2e.yml logs producer consumer
           docker-compose -f docker-compose.e2e.yml exec -T producer /build/target/release/e2e-kafka

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,4 +40,5 @@ jobs:
           pip3 install setuptools
           pip3 install -r requirements.txt
           python3 e2e/run_e2e.py --expected_file=e2e/data/expected_context.yaml --max_retry_times=3 --target_path=/ping
-          docker-compose exec producer /build/target/release/e2e-kafka
+          echo "run e2e-kafka"
+          docker-compose -f docker-compose.e2e.yml exec producer /build/target/release/e2e-kafka

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,4 +40,4 @@ jobs:
           pip3 install setuptools
           pip3 install -r requirements.txt
           python3 e2e/run_e2e.py --expected_file=e2e/data/expected_context.yaml --max_retry_times=3 --target_path=/ping
-          cargo test -p e2e --release -- --nocapture
+          docker-compose exec producer /build/target/release/e2e-kafka

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ cfg-if = "1.0.0"
 futures-core = "0.3.21"
 futures-util = "0.3.21"
 hostname = { version = "0.3.1", optional = true }
+libz-sys = "1.1.9"
 once_cell = "1.14.0"
 parking_lot = "0.12.1"
 portable-atomic = { version = "0.3.13", features = ["float"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rust-version = "1.65"
 [features]
 management = ["hostname", "systemstat"]
 vendored = ["protobuf-src"]
+kafka-reporter = ["rdkafka"]
 
 mock = []  # For internal integration testing only, do not use.
 
@@ -51,6 +52,7 @@ parking_lot = "0.12.1"
 portable-atomic = { version = "0.3.13", features = ["float"] }
 prost = "0.11.0"
 prost-derive = "0.11.0"
+rdkafka = { version = "0.32.2", optional = true }
 serde = { version = "1.0.143", features = ["derive"] }
 systemstat = { version = "0.2.0", optional = true }
 thiserror = "1.0.32"

--- a/README.md
+++ b/README.md
@@ -212,6 +212,42 @@ async fn handle(tracer: Tracer) {
 }
 ```
 
+# Advanced Reporter
+
+The advanced report provides an alternative way to submit the agent collected data to the backend.
+
+## kafka reporter
+
+The Kafka reporter plugin support report traces, metrics, logs, instance properties to Kafka cluster.
+
+Make sure the feature `kafka-reporter` is enabled.
+
+```rust
+#[cfg(feature = "kafka-reporter")]
+mod example {
+    use skywalking::reporter::Report;
+    use skywalking::reporter::kafka::{KafkaReportBuilder, KafkaReporter, RDKafkaClientConfig};
+
+    async fn do_something(reporter: &impl Report) {
+        // ....
+    }
+
+    async fn foo() {
+        let mut client_config = RDKafkaClientConfig::new();
+        client_config
+            .set("bootstrap.servers", "broker:9092")
+            .set("message.timeout.ms", "6000");
+
+        let (reporter, reporting) = KafkaReportBuilder::new(client_config).build().await.unwrap();
+        let handle = reporting.spawn();
+
+        do_something(&reporter);
+
+        handle.await.unwrap();
+    }
+}
+```
+
 # How to compile?
 
 If you have `skywalking-(VERSION).crate`, you can unpack it with the way as follows:

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -220,9 +220,11 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/autocfg/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/base64/0.13.0 0.13.0 Apache-2.0 OR MIT
     https://crates.io/crates/bitflags/1.3.1 1.3.1 Apache-2.0 OR MIT
-    https://crates.io/crates/cc/1.0.0 1.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/cc/1.0.18 1.0.18 Apache-2.0 OR MIT
     https://crates.io/crates/cfg-if/0.1.2 0.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/cfg-if/1.0.0 1.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/derivative/2.0.0 2.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/dtoa/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/either/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/fixedbitset/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/fnv/1.0.5 1.0.5 Apache-2.0 OR MIT
@@ -242,10 +244,12 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/hyper-timeout/0.4.0 0.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/indexmap/1.6.2 1.6.2 Apache-2.0 OR MIT
     https://crates.io/crates/itertools/0.10.0 0.10.0 Apache-2.0 OR MIT
+    https://crates.io/crates/itoa/0.3.0 0.3.0 Apache-2.0 OR MIT
     https://crates.io/crates/itoa/0.4.1 0.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/itoa/1.0.1 1.0.1 Apache-2.0 OR MIT
     https://crates.io/crates/lazy_static/1.4.0 1.4.0 Apache-2.0 OR MIT
     https://crates.io/crates/libc/0.2.114 0.2.114 Apache-2.0 OR MIT
+    https://crates.io/crates/libz-sys/1.1.9 1.1.9 Apache-2.0 OR MIT
     https://crates.io/crates/lock_api/0.4.6 0.4.6 Apache-2.0 OR MIT
     https://crates.io/crates/log/0.4.17 0.4.17 Apache-2.0 OR MIT
     https://crates.io/crates/match_cfg/0.1.0 0.1.0 Apache-2.0 OR MIT
@@ -254,6 +258,7 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/miow/0.3.6 0.3.6 Apache-2.0 OR MIT
     https://crates.io/crates/multimap/0.8.0 0.8.0 Apache-2.0 OR MIT
     https://crates.io/crates/ntapi/0.3.0 0.3.0 Apache-2.0 OR MIT
+    https://crates.io/crates/num-traits/0.1.32 0.1.32 Apache-2.0 OR MIT
     https://crates.io/crates/num_cpus/1.8.0 1.8.0 Apache-2.0 OR MIT
     https://crates.io/crates/num_threads/0.1.2 0.1.2 Apache-2.0 OR MIT
     https://crates.io/crates/once_cell/1.14.0 1.14.0 Apache-2.0 OR MIT
@@ -267,9 +272,11 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/pin-project-internal/1.0.2 1.0.2 Apache-2.0 OR MIT
     https://crates.io/crates/pin-project-lite/0.2.9 0.2.9 Apache-2.0 OR MIT
     https://crates.io/crates/pin-utils/0.1.0 0.1.0 Apache-2.0 OR MIT
+    https://crates.io/crates/pkg-config/0.3.9 0.3.9 Apache-2.0 OR MIT
     https://crates.io/crates/portable-atomic/0.3.13 0.3.13 Apache-2.0 OR MIT
     https://crates.io/crates/ppv-lite86/0.2.8 0.2.8 Apache-2.0 OR MIT
     https://crates.io/crates/prettyplease/0.1.0 0.1.0 Apache-2.0 OR MIT
+    https://crates.io/crates/proc-macro-crate/0.1.4 0.1.4 Apache-2.0 OR MIT
     https://crates.io/crates/proc-macro2/1.0.32 1.0.32 Apache-2.0 OR MIT
     https://crates.io/crates/quote/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/rand/0.4.1 0.4.1 Apache-2.0 OR MIT
@@ -283,6 +290,7 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/scopeguard/1.1.0 1.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/serde/1.0.143 1.0.143 Apache-2.0 OR MIT
     https://crates.io/crates/serde_derive/1.0.143 1.0.143 Apache-2.0 OR MIT
+    https://crates.io/crates/serde_json/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/signal-hook-registry/1.1.1 1.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/smallvec/1.6.1 1.6.1 Apache-2.0 OR MIT
     https://crates.io/crates/socket2/0.3.17 0.3.17 Apache-2.0 OR MIT
@@ -295,10 +303,12 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/thiserror-impl/1.0.32 1.0.32 Apache-2.0 OR MIT
     https://crates.io/crates/time/0.3.9 0.3.9 Apache-2.0 OR MIT
     https://crates.io/crates/tokio-io-timeout/1.0.1 1.0.1 Apache-2.0 OR MIT
+    https://crates.io/crates/toml/0.5.2 0.5.2 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-segmentation/1.2.0 1.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-width/0.1.4 0.1.4 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-xid/0.2.0 0.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/uuid/1.1.2 1.1.2 Apache-2.0 OR MIT
+    https://crates.io/crates/vcpkg/0.2.0 0.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/vec_map/0.8.0 0.8.0 Apache-2.0 OR MIT
     https://crates.io/crates/version_check/0.9.0 0.9.0 Apache-2.0 OR MIT
     https://crates.io/crates/winapi/0.3.9 0.3.9 Apache-2.0 OR MIT
@@ -319,6 +329,8 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://crates.io/crates/fuchsia-zircon/0.3.1 0.3.1 BSD-3-Clause
     https://crates.io/crates/fuchsia-zircon-sys/0.3.1 0.3.1 BSD-3-Clause
+    https://crates.io/crates/num_enum/0.5.0 0.5.0 BSD-3-Clause
+    https://crates.io/crates/num_enum_derive/0.5.0 0.5.0 BSD-3-Clause
 
 ========================================================================
 MIT licenses
@@ -345,6 +357,8 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/mio/0.8.1 0.8.1 MIT
     https://crates.io/crates/nom/7.0.0 7.0.0 MIT
     https://crates.io/crates/proc-macro-error/0.2.0 0.2.0 MIT
+    https://crates.io/crates/rdkafka/0.32.2 0.32.2 MIT
+    https://crates.io/crates/rdkafka-sys/4.5.0+1.9.2 4.5.0+1.9.2 MIT
     https://crates.io/crates/redox_syscall/0.1.38 0.1.38 MIT
     https://crates.io/crates/redox_syscall/0.2.8 0.2.8 MIT
     https://crates.io/crates/slab/0.4.2 0.4.2 MIT

--- a/dist-material/licenses/LICENSE-rdkafka-sys.txt
+++ b/dist-material/licenses/LICENSE-rdkafka-sys.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Federico Giraud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dist-material/licenses/LICENSE-rdkafka.txt
+++ b/dist-material/licenses/LICENSE-rdkafka.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Federico Giraud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -54,6 +54,8 @@ services:
         condition: service_healthy
       consumer:
         condition: service_healthy
+      broker:
+        condition: service_healthy
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.2

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -37,6 +37,8 @@ services:
     depends_on:
       collector:
         condition: service_healthy
+      broker:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8082/healthCheck" ]
       interval: 5s
@@ -57,28 +59,11 @@ services:
       broker:
         condition: service_healthy
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.2
-    container_name: zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-kafka:7.3.2
+    image: landoop/fast-data-dev:3.3
     container_name: broker
     ports:
       - "9092:9092"
-    depends_on:
-      - zookeeper
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     healthcheck:
       test: [ "CMD", "nc", "-zv", "0.0.0.0", "9092"]
       interval: 5s

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -54,3 +54,26 @@ services:
         condition: service_healthy
       consumer:
         condition: service_healthy
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.2
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:7.3.2
+    container_name: broker
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -79,3 +79,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    healthcheck:
+      test: [ "CMD", "nc", "-zv", "0.0.0.0", "9092"]
+      interval: 5s
+      timeout: 5s

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -24,7 +24,11 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-skywalking = { path = ".." }
+skywalking = { path = "..", features = ["kafka-reporter"] }
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 structopt = "0.3"
+
+[dev-dependencies]
+rdkafka = "0.32.2"
+prost = "0.11.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -23,12 +23,14 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
-[dependencies]
-skywalking = { path = "..", features = ["kafka-reporter"] }
-hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
-structopt = "0.3"
+[[bin]]
+name = "e2e-kafka"
+path = "src/e2e_kafka.rs"
 
-[dev-dependencies]
-rdkafka = "0.32.2"
+[dependencies]
+hyper = { version = "0.14", features = ["full"] }
 prost = "0.11.0"
+rdkafka = "0.32.2"
+skywalking = { path = "..", features = ["kafka-reporter"] }
+structopt = "0.3"
+tokio = { version = "1", features = ["full"] }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -22,6 +22,7 @@ authors = ["Apache Software Foundation"]
 edition = "2021"
 publish = false
 license = "Apache-2.0"
+default-run = "e2e"
 
 [[bin]]
 name = "e2e-kafka"

--- a/e2e/docker/Dockerfile
+++ b/e2e/docker/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update && apt-get install -y cmake protobuf-compiler
 WORKDIR /build
 COPY . /build/
 RUN cargo build --release --workspace
+ENV RUST_BACKTRACE=1
 ENTRYPOINT ["/build/target/release/e2e"]

--- a/e2e/src/e2e_kafka.rs
+++ b/e2e/src/e2e_kafka.rs
@@ -265,7 +265,7 @@ fn create_consumer(topic: &str) -> StreamConsumer {
     let consumer: StreamConsumer = ClientConfig::new()
         .set("bootstrap.servers", "broker:9092")
         .set("broker.address.family", "v4")
-        .set("session.timeout.ms", "6000")
+        .set("session.timeout.ms", "30000")
         .set("enable.auto.commit", "true")
         .set("auto.offset.reset", "earliest")
         .set("enable.auto.offset.store", "true")
@@ -277,7 +277,7 @@ fn create_consumer(topic: &str) -> StreamConsumer {
 }
 
 async fn consumer_recv<T: Message + Default>(consumer: &StreamConsumer) -> T {
-    let message = timeout(Duration::from_secs(6), consumer.recv())
+    let message = timeout(Duration::from_secs(12), consumer.recv())
         .await
         .unwrap()
         .unwrap();

--- a/e2e/src/e2e_kafka.rs
+++ b/e2e/src/e2e_kafka.rs
@@ -263,7 +263,7 @@ fn check_log(log: &LogData) {
 
 fn create_consumer(topic: &str) -> StreamConsumer {
     let consumer: StreamConsumer = ClientConfig::new()
-        .set("bootstrap.servers", "localhost:9092")
+        .set("bootstrap.servers", "broker:9092")
         .set("broker.address.family", "v4")
         .set("session.timeout.ms", "6000")
         .set("enable.auto.commit", "true")

--- a/e2e/src/e2e_kafka.rs
+++ b/e2e/src/e2e_kafka.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#![allow(clippy::bool_assert_comparison)]
+
 use prost::Message;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},

--- a/e2e/src/e2e_kafka.rs
+++ b/e2e/src/e2e_kafka.rs
@@ -26,7 +26,6 @@ use skywalking::proto::v3::{
 use std::time::Duration;
 use tokio::time::timeout;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn segment() {
     let consumer = create_consumer("skywalking-segments");
 
@@ -141,7 +140,6 @@ fn check_segment(segment: &SegmentObject) {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn meter() {
     let consumer = create_consumer("skywalking-meters");
 
@@ -192,7 +190,6 @@ fn check_meter(meter: &MeterData) {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn log() {
     let consumer = create_consumer("skywalking-logs");
 
@@ -284,4 +281,11 @@ async fn consumer_recv<T: Message + Default>(consumer: &StreamConsumer) -> T {
         .unwrap();
     let value = message.payload_view::<[u8]>().unwrap().unwrap();
     Message::decode(value).unwrap()
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    segment().await;
+    meter().await;
+    log().await;
 }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -243,7 +243,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let handle1 = reporter1.reporting().await.spawn();
 
     let mut client_config = RDKafkaClientConfig::new();
-    client_config.set("bootstrap.servers", "broker:9092");
+    client_config
+        .set("bootstrap.servers", "broker:9092")
+        .set("message.timeout.ms", "6000");
     let (reporter2, reporting) = KafkaReportBuilder::new(client_config)
         .with_err_handle(|message, err| {
             eprintln!(

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -29,7 +29,11 @@ use skywalking::{
         meter::{Counter, Gauge, Histogram},
         metricer::Metricer,
     },
-    reporter::grpc::GrpcReporter,
+    reporter::{
+        grpc::GrpcReporter,
+        kafka::{KafkaReportBuilder, KafkaReporter, RDKafkaClientConfig},
+        CollectItem, Report,
+    },
     trace::{
         propagation::{
             context::SKYWALKING_HTTP_CONTEXT_HEADER_KEY, decoder::decode_propagation,
@@ -40,6 +44,7 @@ use skywalking::{
 };
 use std::{convert::Infallible, error::Error, net::SocketAddr};
 use structopt::StructOpt;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 static NOT_FOUND_MSG: &str = "not found";
 static SUCCESS_MSG: &str = "Success";
@@ -210,11 +215,50 @@ struct Opt {
     mode: String,
 }
 
+#[derive(Clone)]
+struct CombineReporter {
+    grpc_reporter: GrpcReporter<UnboundedSender<CollectItem>, UnboundedReceiver<CollectItem>>,
+    kafka_reporter: KafkaReporter<UnboundedSender<CollectItem>>,
+}
+
+impl Report for CombineReporter {
+    fn report(&self, item: CollectItem) {
+        let typ = match &item {
+            CollectItem::Trace(_) => "trace",
+            CollectItem::Log(_) => "log",
+            CollectItem::Meter(_) => "meter",
+            _ => "unknown",
+        };
+        println!("report item type: {:?}", typ);
+        self.grpc_reporter.report(item.clone());
+        self.kafka_reporter.report(item);
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let opt = Opt::from_args();
-    let reporter = GrpcReporter::connect("http://collector:19876").await?;
-    let handle = reporter.reporting().await.spawn();
+
+    let reporter1 = GrpcReporter::connect("http://collector:19876").await?;
+    let handle1 = reporter1.reporting().await.spawn();
+
+    let mut client_config = RDKafkaClientConfig::new();
+    client_config.set("bootstrap.servers", "broker:9092");
+    let (reporter2, reporting) = KafkaReportBuilder::new(client_config)
+        .with_err_handle(|message, err| {
+            eprintln!(
+                "kafka reporter failed, message: {}, err: {:?}",
+                message, err
+            );
+        })
+        .build()
+        .await?;
+    let handle2 = reporting.spawn();
+
+    let reporter = CombineReporter {
+        grpc_reporter: reporter1,
+        kafka_reporter: reporter2,
+    };
 
     if opt.mode == "consumer" {
         tracer::set_global_tracer(Tracer::new("consumer", "node_0", reporter.clone()));
@@ -229,7 +273,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         unreachable!()
     }
 
-    handle.await?;
+    handle1.await?;
+    handle2.await?;
 
     Ok(())
 }

--- a/e2e/tests/kafka.rs
+++ b/e2e/tests/kafka.rs
@@ -1,0 +1,291 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use prost::Message;
+use rdkafka::{
+    consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer},
+    error::KafkaResult,
+    ClientConfig, ClientContext, Message as _, Offset, TopicPartitionList,
+};
+use skywalking::{
+    metrics::meter::Histogram,
+    proto::v3::{
+        log_data_body::Content, meter_data::Metric, JsonLog, KeyStringValuePair, LogData,
+        LogDataBody, LogTags, MeterData, RefType, SegmentObject, SpanLayer, SpanType,
+    },
+};
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn segment() {
+    let consumer = create_consumer("skywalking-segments");
+
+    for _ in 0..3 {
+        let segment: SegmentObject = consumer_recv(&consumer).await;
+        check_segment(&segment);
+    }
+}
+
+fn check_segment(segment: &SegmentObject) {
+    dbg!(segment);
+
+    assert_eq!(segment.service_instance, "node_0");
+
+    if segment.service == "consumer" {
+        assert_eq!(segment.spans.len(), 1);
+
+        assert_eq!(segment.spans[0].span_id, 0);
+        assert_eq!(segment.spans[0].parent_span_id, -1);
+        assert_eq!(segment.spans[0].operation_name, "/pong");
+        assert_eq!(segment.spans[0].peer, "");
+        assert_eq!(segment.spans[0].span_type, SpanType::Entry as i32);
+        assert_eq!(segment.spans[0].span_layer, SpanLayer::Http as i32);
+        assert_eq!(segment.spans[0].component_id, 11000);
+        assert_eq!(segment.spans[0].is_error, false);
+        assert_eq!(segment.spans[0].tags.len(), 0);
+        assert_eq!(segment.spans[0].logs.len(), 0);
+        assert_eq!(segment.spans[0].refs.len(), 1);
+
+        assert_eq!(
+            segment.spans[0].refs[0].ref_type,
+            RefType::CrossProcess as i32
+        );
+        assert_eq!(segment.spans[0].refs[0].parent_span_id, 1);
+        assert_eq!(segment.spans[0].refs[0].parent_service, "producer");
+        assert_eq!(segment.spans[0].refs[0].parent_service_instance, "node_0");
+        assert_eq!(segment.spans[0].refs[0].parent_endpoint, "/pong");
+        assert_eq!(
+            segment.spans[0].refs[0].network_address_used_at_peer,
+            "consumer:8082"
+        );
+    } else if segment.service == "producer" {
+        if segment.spans.last().unwrap().operation_name == "/ping" {
+            assert_eq!(segment.spans.len(), 3);
+
+            assert_eq!(segment.spans[0].span_id, 1);
+            assert_eq!(segment.spans[0].parent_span_id, 0);
+            assert_eq!(segment.spans[0].operation_name, "/pong");
+            assert_eq!(segment.spans[0].peer, "consumer:8082");
+            assert_eq!(segment.spans[0].span_type, SpanType::Exit as i32);
+            assert_eq!(segment.spans[0].span_layer, SpanLayer::Unknown as i32);
+            assert_eq!(segment.spans[0].component_id, 11000);
+            assert_eq!(segment.spans[0].is_error, false);
+            assert_eq!(segment.spans[0].tags.len(), 0);
+            assert_eq!(segment.spans[0].logs.len(), 0);
+            assert_eq!(segment.spans[0].refs.len(), 0);
+
+            assert_eq!(segment.spans[1].span_id, 2);
+            assert_eq!(segment.spans[1].parent_span_id, 0);
+            assert_eq!(segment.spans[1].operation_name, "async-job");
+            assert_eq!(segment.spans[1].peer, "");
+            assert_eq!(segment.spans[1].span_type, SpanType::Local as i32);
+            assert_eq!(segment.spans[1].span_layer, SpanLayer::Unknown as i32);
+            assert_eq!(segment.spans[1].component_id, 11000);
+            assert_eq!(segment.spans[1].is_error, false);
+            assert_eq!(segment.spans[1].tags.len(), 0);
+            assert_eq!(segment.spans[1].logs.len(), 0);
+            assert_eq!(segment.spans[1].refs.len(), 0);
+
+            assert_eq!(segment.spans[2].span_id, 0);
+            assert_eq!(segment.spans[2].parent_span_id, -1);
+            assert_eq!(segment.spans[2].operation_name, "/ping");
+            assert_eq!(segment.spans[2].peer, "");
+            assert_eq!(segment.spans[2].span_type, SpanType::Entry as i32);
+            assert_eq!(segment.spans[2].span_layer, SpanLayer::Http as i32);
+            assert_eq!(segment.spans[2].component_id, 11000);
+            assert_eq!(segment.spans[2].is_error, false);
+            assert_eq!(segment.spans[2].tags.len(), 0);
+            assert_eq!(segment.spans[2].logs.len(), 0);
+            assert_eq!(segment.spans[2].refs.len(), 0);
+        } else if segment.spans.last().unwrap().operation_name == "async-callback" {
+            assert_eq!(segment.spans.len(), 1);
+
+            assert_eq!(segment.spans[0].span_id, 0);
+            assert_eq!(segment.spans[0].parent_span_id, -1);
+            assert_eq!(segment.spans[0].peer, "");
+            assert_eq!(segment.spans[0].span_type, SpanType::Entry as i32);
+            assert_eq!(segment.spans[0].span_layer, SpanLayer::Http as i32);
+            assert_eq!(segment.spans[0].component_id, 11000);
+            assert_eq!(segment.spans[0].is_error, false);
+            assert_eq!(segment.spans[0].tags.len(), 0);
+            assert_eq!(segment.spans[0].logs.len(), 0);
+            assert_eq!(segment.spans[0].refs.len(), 1);
+
+            assert_eq!(
+                segment.spans[0].refs[0].ref_type,
+                RefType::CrossThread as i32
+            );
+            assert_eq!(segment.spans[0].refs[0].parent_span_id, 2);
+            assert_eq!(segment.spans[0].refs[0].parent_service, "producer");
+            assert_eq!(segment.spans[0].refs[0].parent_service_instance, "node_0");
+            assert_eq!(segment.spans[0].refs[0].parent_endpoint, "async-job");
+            assert_eq!(segment.spans[0].refs[0].network_address_used_at_peer, "");
+        } else {
+            panic!(
+                "unknown operation_name {}",
+                segment.spans.last().unwrap().operation_name
+            );
+        }
+    } else {
+        panic!("unknown service {}", segment.service);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn meter() {
+    let consumer = create_consumer("skywalking-meters");
+
+    for _ in 0..3 {
+        let meter: MeterData = consumer_recv(&consumer).await;
+        check_meter(&meter);
+    }
+}
+
+fn check_meter(meter: &MeterData) {
+    dbg!(meter);
+
+    assert_eq!(meter.service, "consumer");
+    assert_eq!(meter.service_instance, "node_0");
+
+    match &meter.metric {
+        Some(Metric::SingleValue(value)) => {
+            assert_eq!(value.name, "instance_trace_count");
+
+            if value.labels[0].name == "region" && value.labels[0].value == "us-west" {
+                assert_eq!(value.labels[1].name, "az");
+                assert_eq!(value.labels[1].value, "az-1");
+                assert_eq!(value.value, 30.0);
+            } else if value.labels[0].name == "region" && value.labels[0].value == "us-east" {
+                assert_eq!(value.labels[1].name, "az");
+                assert_eq!(value.labels[1].value, "az-3");
+                assert_eq!(value.value, 20.0);
+            } else {
+                panic!("unknown label {:?}", &value.labels[0]);
+            }
+        }
+        Some(Metric::Histogram(value)) => {
+            assert_eq!(value.name, "instance_trace_count");
+            assert_eq!(value.labels[0].name, "region");
+            assert_eq!(value.labels[0].value, "us-north");
+            assert_eq!(value.labels[1].name, "az");
+            assert_eq!(value.labels[1].value, "az-1");
+            assert_eq!(value.values[0].bucket, 10.0);
+            assert_eq!(value.values[0].count, 1);
+            assert_eq!(value.values[1].bucket, 20.0);
+            assert_eq!(value.values[1].count, 2);
+            assert_eq!(value.values[2].bucket, 30.0);
+            assert_eq!(value.values[2].count, 0);
+        }
+        _ => {
+            panic!("unknown metric");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn log() {
+    let consumer = create_consumer("skywalking-logs");
+
+    for _ in 0..3 {
+        let log: LogData = consumer_recv(&consumer).await;
+        check_log(&log);
+    }
+}
+
+fn check_log(log: &LogData) {
+    dbg!(log);
+
+    if log.service == "producer" && log.service_instance == "node_0" {
+        assert_eq!(log.endpoint, "/ping");
+
+        match &log.body.as_ref().unwrap().content {
+            Some(Content::Json(json)) => {
+                assert_eq!(json.json, r#"{"message": "handle ping"}"#);
+                assert_eq!(log.trace_context, None);
+                assert_eq!(
+                    log.tags,
+                    Some(LogTags {
+                        data: vec![KeyStringValuePair {
+                            key: "level".to_string(),
+                            value: "DEBUG".to_string()
+                        }]
+                    })
+                );
+            }
+            Some(Content::Text(text)) => {
+                assert_eq!(text.text, "do http request");
+                assert_eq!(log.trace_context.as_ref().unwrap().span_id, 1);
+                assert_eq!(
+                    log.tags,
+                    Some(LogTags {
+                        data: vec![KeyStringValuePair {
+                            key: "level".to_string(),
+                            value: "INFO".to_string()
+                        }]
+                    })
+                );
+            }
+            body => {
+                panic!("unknown log body {:?}", body);
+            }
+        }
+    } else if log.service == "consumer" && log.service_instance == "node_0" {
+        assert_eq!(log.endpoint, "/pong");
+        assert_eq!(
+            log.body.as_ref().unwrap().content,
+            Some(Content::Json(JsonLog {
+                json: r#"{"message": "handle pong"}"#.to_string()
+            }))
+        );
+        assert_eq!(log.trace_context, None);
+        assert_eq!(
+            log.tags,
+            Some(LogTags {
+                data: vec![KeyStringValuePair {
+                    key: "level".to_string(),
+                    value: "DEBUG".to_string()
+                }]
+            })
+        );
+    } else {
+        panic!("unknown log {} {}", log.service, log.service_instance);
+    }
+}
+
+fn create_consumer(topic: &str) -> StreamConsumer {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .set("broker.address.family", "v4")
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "true")
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.offset.store", "true")
+        .set("group.id", topic)
+        .create()
+        .unwrap();
+    consumer.subscribe(&[topic]).unwrap();
+    consumer
+}
+
+async fn consumer_recv<T: Message + Default>(consumer: &StreamConsumer) -> T {
+    let message = timeout(Duration::from_secs(6), consumer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let value = message.payload_view::<[u8]>().unwrap().unwrap();
+    Message::decode(value).unwrap()
+}

--- a/e2e/tests/kafka.rs
+++ b/e2e/tests/kafka.rs
@@ -16,16 +16,12 @@
 
 use prost::Message;
 use rdkafka::{
-    consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer},
-    error::KafkaResult,
-    ClientConfig, ClientContext, Message as _, Offset, TopicPartitionList,
+    consumer::{Consumer, StreamConsumer},
+    ClientConfig, Message as _,
 };
-use skywalking::{
-    metrics::meter::Histogram,
-    proto::v3::{
-        log_data_body::Content, meter_data::Metric, JsonLog, KeyStringValuePair, LogData,
-        LogDataBody, LogTags, MeterData, RefType, SegmentObject, SpanLayer, SpanType,
-    },
+use skywalking::proto::v3::{
+    log_data_body::Content, meter_data::Metric, JsonLog, KeyStringValuePair, LogData, LogTags,
+    MeterData, RefType, SegmentObject, SpanLayer, SpanType,
 };
 use std::time::Duration;
 use tokio::time::timeout;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -44,6 +44,11 @@ pub enum Error {
     #[error("tokio join failed: {0}")]
     TokioJoin(#[from] tokio::task::JoinError),
 
+    /// Kafka reporter error.
+    #[cfg(feature = "kafka-reporter")]
+    #[error("kafka reporter failed: {0}")]
+    KafkaReporter(crate::reporter::kafka::Error),
+
     /// Other uncovered errors.
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + 'static>),

--- a/src/proto/v3/mod.rs
+++ b/src/proto/v3/mod.rs
@@ -18,6 +18,7 @@
 
 #![allow(missing_docs)]
 #![allow(rustdoc::invalid_html_tags)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 use crate::common::system_time::{fetch_time, TimePeriod};
 

--- a/src/reporter/kafka.rs
+++ b/src/reporter/kafka.rs
@@ -65,8 +65,8 @@ impl State {
     }
 }
 
-/// Reporter which just print the collect items, not actual report to server,
-/// for debug usage.
+/// The Kafka reporter plugin support report traces, metrics, logs, instance
+/// properties to Kafka cluster.
 pub struct KafkaReportBuilder<P, C> {
     state: Arc<State>,
     producer: Arc<P>,
@@ -77,7 +77,7 @@ pub struct KafkaReportBuilder<P, C> {
 }
 
 impl KafkaReportBuilder<mpsc::UnboundedSender<CollectItem>, mpsc::UnboundedReceiver<CollectItem>> {
-    /// Create builder, with rdkafka future.
+    /// Create builder, with rdkafka client configuration.
     pub fn new(client_config: RDKafkaClientConfig) -> Self {
         let (producer, consumer) = mpsc::unbounded_channel();
         Self::new_with_pc(client_config, producer, consumer)

--- a/src/reporter/kafka.rs
+++ b/src/reporter/kafka.rs
@@ -1,0 +1,343 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Kafka implementation of [Report].
+
+use super::{CollectItemConsume, CollectItemProduce};
+use crate::reporter::{CollectItem, Report};
+pub use rdkafka::config::{ClientConfig as RDkafkaClientConfig, RDKafkaLogLevel};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::{
+    error,
+    future::{pending, Future},
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering::Relaxed},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{select, spawn, sync::mpsc, task::JoinHandle, try_join};
+use tracing::error;
+
+/// Kafka reporter error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// ksKafka error.
+    #[error(transparent)]
+    RdKafka(#[from] rdkafka::error::KafkaError),
+
+    /// kafka topic not found
+    #[error("topic not found: {topic}")]
+    TopicNotFound {
+        /// Name of kafka topic.
+        topic: String,
+    },
+}
+
+type DynErrHandler = dyn Fn(&str, &dyn error::Error) + Send + Sync + 'static;
+
+fn default_err_handle(message: &str, err: &dyn error::Error) {
+    error!(?err, "{}", message);
+}
+
+#[derive(Default)]
+struct State {
+    is_closing: AtomicBool,
+}
+
+impl State {
+    fn is_closing(&self) -> bool {
+        self.is_closing.load(Relaxed)
+    }
+}
+
+/// Reporter which just print the collect items, not actual report to server,
+/// for debug usage.
+pub struct KafkaReportBuilder<P, C> {
+    state: Arc<State>,
+    producer: Arc<P>,
+    consumer: C,
+    client_config: RDkafkaClientConfig,
+    namespace: Option<String>,
+    err_handle: Arc<DynErrHandler>,
+}
+
+impl KafkaReportBuilder<mpsc::UnboundedSender<CollectItem>, mpsc::UnboundedReceiver<CollectItem>> {
+    /// Create builder, with rdkafka future.
+    pub fn new(client_config: RDkafkaClientConfig) -> Self {
+        let (producer, consumer) = mpsc::unbounded_channel();
+        Self::new_with_pc(client_config, producer, consumer)
+    }
+}
+
+impl<P: CollectItemProduce, C: CollectItemConsume> KafkaReportBuilder<P, C> {
+    /// Special purpose, used for user-defined produce and consume operations,
+    /// usually you can use [KafkaReportBuilder::new].
+    pub fn new_with_pc(client_config: RDkafkaClientConfig, producer: P, consumer: C) -> Self {
+        Self {
+            state: Default::default(),
+            producer: Arc::new(producer),
+            consumer,
+            client_config,
+            namespace: None,
+            err_handle: Arc::new(default_err_handle),
+        }
+    }
+
+    /// Set error handle. By default, the error will be logged.
+    pub fn with_err_handle(
+        mut self,
+        handle: impl Fn(&str, &dyn error::Error) + Send + Sync + 'static,
+    ) -> Self {
+        self.err_handle = Arc::new(handle);
+        self
+    }
+
+    /// Use to isolate multi OAP server when using same Kafka cluster (final
+    /// topic name will append namespace before Kafka topics with - ).
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = Some(namespace.into());
+        self
+    }
+
+    /// Build the Reporter implemented [Report] in the foreground, and the
+    /// handle to push data to kafka in the background.
+    pub async fn build(self) -> Result<(KafkaReporter<P>, KafkaReporting<C>), Error> {
+        let kafka_producer = KafkaProducer::new(
+            self.client_config.create()?,
+            self.err_handle.clone(),
+            self.namespace,
+        )
+        .await?;
+        Ok((
+            KafkaReporter {
+                state: self.state.clone(),
+                producer: self.producer,
+                err_handle: self.err_handle,
+            },
+            KafkaReporting {
+                state: self.state,
+                consumer: self.consumer,
+                kafka_producer,
+                shutdown_signal: Box::pin(pending()),
+            },
+        ))
+    }
+}
+
+/// The kafka reporter implemented [Report].
+pub struct KafkaReporter<P> {
+    state: Arc<State>,
+    producer: Arc<P>,
+    err_handle: Arc<DynErrHandler>,
+}
+
+impl<P> Clone for KafkaReporter<P> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            producer: self.producer.clone(),
+            err_handle: self.err_handle.clone(),
+        }
+    }
+}
+
+impl<P: CollectItemProduce> Report for KafkaReporter<P> {
+    fn report(&self, item: CollectItem) {
+        if !self.state.is_closing() {
+            if let Err(e) = self.producer.produce(item) {
+                (self.err_handle)("report collect item failed", &*e);
+            }
+        }
+    }
+}
+
+/// The handle to push data to kafka.
+pub struct KafkaReporting<C> {
+    state: Arc<State>,
+    consumer: C,
+    kafka_producer: KafkaProducer,
+    shutdown_signal: Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>,
+}
+
+impl<C: CollectItemConsume> KafkaReporting<C> {
+    /// Quit when shutdown_signal received.
+    ///
+    /// Accept a `shutdown_signal` argument as a graceful shutdown signal.
+    pub fn with_graceful_shutdown(
+        mut self,
+        shutdown_signal: impl Future<Output = ()> + Send + Sync + 'static,
+    ) -> Self {
+        self.shutdown_signal = Box::pin(shutdown_signal);
+        self
+    }
+
+    /// Spawn the reporting in background.
+    pub fn spawn(self) -> ReportingJoinHandle {
+        let handle = spawn(async move {
+            let KafkaReporting {
+                state,
+                mut consumer,
+                mut kafka_producer,
+                shutdown_signal,
+            } = self;
+
+            let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel();
+
+            let work_fut = async move {
+                loop {
+                    select! {
+                        item = consumer.consume() => {
+                            match item {
+                                Ok(Some(item)) => {
+                                    kafka_producer.produce(item).await;
+                                }
+                                Ok(None) => break,
+                                Err(err) => return Err(crate::Error::Other(err)),
+                            }
+                        }
+                        _ =  shutdown_rx.recv() => break,
+                    }
+                }
+
+                state.is_closing.store(true, Relaxed);
+
+                // Flush.
+                loop {
+                    match consumer.try_consume().await {
+                        Ok(Some(item)) => {
+                            kafka_producer.produce(item).await;
+                        }
+                        Ok(None) => break,
+                        Err(err) => return Err(err.into()),
+                    }
+                }
+
+                Ok::<_, crate::Error>(())
+            };
+
+            let shutdown_fut = async move {
+                shutdown_signal.await;
+                shutdown_tx
+                    .send(())
+                    .map_err(|e| crate::Error::Other(Box::new(e)))?;
+                Ok(())
+            };
+
+            try_join!(work_fut, shutdown_fut)?;
+
+            Ok(())
+        });
+        ReportingJoinHandle { handle }
+    }
+}
+
+/// Handle of [KafkaReporting::spawn].
+pub struct ReportingJoinHandle {
+    handle: JoinHandle<crate::Result<()>>,
+}
+
+impl Future for ReportingJoinHandle {
+    type Output = crate::Result<()>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        Pin::new(&mut self.handle).poll(cx).map(|rs| rs?)
+    }
+}
+
+struct TopicNames {
+    segment: String,
+    management: String,
+    meter: String,
+    log: String,
+}
+
+impl TopicNames {
+    const TOPIC_LOG: &str = "skywalking-logs";
+    const TOPIC_MANAGEMENT: &str = "skywalking-managements";
+    const TOPIC_METER: &str = "skywalking-meters";
+    const TOPIC_SEGMENT: &str = "skywalking-segments";
+
+    fn new(namespace: Option<&str>) -> Self {
+        Self {
+            segment: Self::real_topic_name(namespace, Self::TOPIC_SEGMENT),
+            management: Self::real_topic_name(namespace, Self::TOPIC_MANAGEMENT),
+            meter: Self::real_topic_name(namespace, Self::TOPIC_METER),
+            log: Self::real_topic_name(namespace, Self::TOPIC_LOG),
+        }
+    }
+
+    fn real_topic_name(namespace: Option<&str>, topic_name: &str) -> String {
+        namespace
+            .map(|namespace| format!("{}-{}", namespace, topic_name))
+            .unwrap_or_else(|| topic_name.to_string())
+    }
+}
+
+struct KafkaProducer {
+    topic_names: TopicNames,
+    client: FutureProducer,
+    err_handle: Arc<DynErrHandler>,
+}
+
+impl KafkaProducer {
+    async fn new(
+        client: FutureProducer,
+        err_handle: Arc<DynErrHandler>,
+        namespace: Option<String>,
+    ) -> Result<Self, Error> {
+        let topic_names = TopicNames::new(namespace.as_deref());
+        Ok(Self {
+            client,
+            err_handle,
+            topic_names,
+        })
+    }
+
+    async fn produce(&mut self, item: CollectItem) {
+        let (topic_name, key) = match &item {
+            CollectItem::Trace(item) => (
+                &self.topic_names.segment,
+                item.trace_segment_id.as_bytes().to_vec(),
+            ),
+            CollectItem::Log(item) => (&self.topic_names.log, item.service.as_bytes().to_vec()),
+            CollectItem::Meter(item) => (
+                &self.topic_names.meter,
+                item.service_instance.as_bytes().to_vec(),
+            ),
+            CollectItem::Instance(item) => (
+                &self.topic_names.management,
+                format!("register-{}", &item.service_instance).into_bytes(),
+            ),
+            CollectItem::Ping(item) => (
+                &self.topic_names.log,
+                item.service_instance.as_bytes().to_vec(),
+            ),
+        };
+
+        let payload = item.encode_to_vec();
+        let record = FutureRecord::to(topic_name).payload(&payload).key(&key);
+
+        if let Err((err, _)) = self.client.send(record, Duration::from_secs(0)).await {
+            (self.err_handle)("Collect data to kafka failed", &err);
+        }
+    }
+}

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -17,14 +17,19 @@
 //! Reporter contains common `Report` trait and the implementations.
 
 pub mod grpc;
+#[cfg(feature = "kafka-reporter")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kafka-reporter")))]
+pub mod kafka;
 pub mod print;
 
 #[cfg(feature = "management")]
 use crate::proto::v3::{InstancePingPkg, InstanceProperties};
 use crate::proto::v3::{LogData, MeterData, SegmentObject};
+use prost::Message;
 use serde::{Deserialize, Serialize};
-use std::{ops::Deref, sync::Arc};
-use tokio::sync::OnceCell;
+use std::{error::Error, ops::Deref, sync::Arc};
+use tokio::sync::{mpsc, OnceCell};
+use tonic::async_trait;
 
 /// Collect item of protobuf object.
 #[derive(Debug, Serialize, Deserialize)]
@@ -44,6 +49,20 @@ pub enum CollectItem {
     #[cfg(feature = "management")]
     #[cfg_attr(docsrs, doc(cfg(feature = "management")))]
     Ping(Box<InstancePingPkg>),
+}
+
+impl CollectItem {
+    pub(crate) fn encode_to_vec(self) -> Vec<u8> {
+        match self {
+            CollectItem::Trace(item) => item.encode_to_vec(),
+            CollectItem::Log(item) => item.encode_to_vec(),
+            CollectItem::Meter(item) => item.encode_to_vec(),
+            #[cfg(feature = "management")]
+            CollectItem::Instance(item) => item.encode_to_vec(),
+            #[cfg(feature = "management")]
+            CollectItem::Ping(item) => item.encode_to_vec(),
+        }
+    }
 }
 
 pub(crate) type DynReport = dyn Report + Send + Sync + 'static;
@@ -74,5 +93,90 @@ impl<T: Report> Report for Arc<T> {
 impl<T: Report> Report for OnceCell<T> {
     fn report(&self, item: CollectItem) {
         Report::report(self.get().expect("OnceCell is empty"), item)
+    }
+}
+
+/// Special purpose, used for user-defined production operations. Generally, it
+/// does not need to be handled.
+pub trait CollectItemProduce: Send + Sync + 'static {
+    /// Produce the collect item non-blocking.
+    fn produce(&self, item: CollectItem) -> Result<(), Box<dyn Error>>;
+}
+
+impl CollectItemProduce for () {
+    fn produce(&self, _item: CollectItem) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+}
+
+impl CollectItemProduce for mpsc::Sender<CollectItem> {
+    fn produce(&self, item: CollectItem) -> Result<(), Box<dyn Error>> {
+        Ok(self.blocking_send(item)?)
+    }
+}
+
+impl CollectItemProduce for mpsc::UnboundedSender<CollectItem> {
+    fn produce(&self, item: CollectItem) -> Result<(), Box<dyn Error>> {
+        Ok(self.send(item)?)
+    }
+}
+
+/// Special purpose, used for user-defined consume operations. Generally, it
+/// does not need to be handled.
+#[async_trait]
+pub trait CollectItemConsume: Send + Sync + 'static {
+    /// Consume the collect item blocking.
+    async fn consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>>;
+
+    /// Try to consume the collect item non-blocking.
+    async fn try_consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>>;
+}
+
+#[async_trait]
+impl CollectItemConsume for () {
+    async fn consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        Ok(None)
+    }
+
+    async fn try_consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        Ok(None)
+    }
+}
+
+#[async_trait]
+impl CollectItemConsume for mpsc::Receiver<CollectItem> {
+    async fn consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        Ok(self.recv().await)
+    }
+
+    async fn try_consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        use mpsc::error::TryRecvError;
+
+        match self.try_recv() {
+            Ok(item) => Ok(Some(item)),
+            Err(e) => match e {
+                TryRecvError::Empty => Ok(None),
+                TryRecvError::Disconnected => Err(Box::new(e)),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CollectItemConsume for mpsc::UnboundedReceiver<CollectItem> {
+    async fn consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        Ok(self.recv().await)
+    }
+
+    async fn try_consume(&mut self) -> Result<Option<CollectItem>, Box<dyn Error + Send>> {
+        use mpsc::error::TryRecvError;
+
+        match self.try_recv() {
+            Ok(item) => Ok(Some(item)),
+            Err(e) => match e {
+                TryRecvError::Empty => Ok(None),
+                TryRecvError::Disconnected => Err(Box::new(e)),
+            },
+        }
     }
 }


### PR DESCRIPTION
Add optional kafka reporter support.

- [x] Move `CollectItemProduce` and `CollectItemConsume` from `report::grpc` module to `report`.
- [x] Implement kafka reporter.
- [x] Update documents.
- [x] Add integration tests.