### PR TITLE
Rename `AbstractSpan` to `HandleSpanObject`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ thread or coroutine.
 ```rust
 use skywalking::{
     trace::tracer::Tracer,
-    trace::span::AbstractSpan,
+    trace::span::HandleSpanObject,
 };
 
 async fn handle(tracer: Tracer) {

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -277,8 +277,8 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/ppv-lite86/0.2.8 0.2.8 Apache-2.0 OR MIT
     https://crates.io/crates/prettyplease/0.1.0 0.1.0 Apache-2.0 OR MIT
     https://crates.io/crates/proc-macro-crate/0.1.4 0.1.4 Apache-2.0 OR MIT
-    https://crates.io/crates/proc-macro2/1.0.32 1.0.32 Apache-2.0 OR MIT
-    https://crates.io/crates/quote/1.0.0 1.0.0 Apache-2.0 OR MIT
+    https://crates.io/crates/proc-macro2/1.0.52 1.0.52 Apache-2.0 OR MIT
+    https://crates.io/crates/quote/1.0.26 1.0.26 Apache-2.0 OR MIT
     https://crates.io/crates/rand/0.4.1 0.4.1 Apache-2.0 OR MIT
     https://crates.io/crates/rand/0.8.0 0.8.0 Apache-2.0 OR MIT
     https://crates.io/crates/rand_chacha/0.3.0 0.3.0 Apache-2.0 OR MIT
@@ -288,8 +288,8 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/regex-syntax/0.6.25 0.6.25 Apache-2.0 OR MIT
     https://crates.io/crates/remove_dir_all/0.5.0 0.5.0 Apache-2.0 OR MIT
     https://crates.io/crates/scopeguard/1.1.0 1.1.0 Apache-2.0 OR MIT
-    https://crates.io/crates/serde/1.0.143 1.0.143 Apache-2.0 OR MIT
-    https://crates.io/crates/serde_derive/1.0.143 1.0.143 Apache-2.0 OR MIT
+    https://crates.io/crates/serde/1.0.157 1.0.157 Apache-2.0 OR MIT
+    https://crates.io/crates/serde_derive/1.0.157 1.0.157 Apache-2.0 OR MIT
     https://crates.io/crates/serde_json/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/signal-hook-registry/1.1.1 1.1.1 Apache-2.0 OR MIT
     https://crates.io/crates/smallvec/1.6.1 1.6.1 Apache-2.0 OR MIT
@@ -297,13 +297,15 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
     https://crates.io/crates/socket2/0.4.4 0.4.4 Apache-2.0 OR MIT
     https://crates.io/crates/structopt/0.3.0 0.3.0 Apache-2.0 OR MIT
     https://crates.io/crates/structopt-derive/0.3.0 0.3.0 Apache-2.0 OR MIT
-    https://crates.io/crates/syn/1.0.90 1.0.90 Apache-2.0 OR MIT
+    https://crates.io/crates/syn/1.0.85 1.0.85 Apache-2.0 OR MIT
+    https://crates.io/crates/syn/2.0.0 2.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/tempfile/3.0.2 3.0.2 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror/1.0.32 1.0.32 Apache-2.0 OR MIT
     https://crates.io/crates/thiserror-impl/1.0.32 1.0.32 Apache-2.0 OR MIT
     https://crates.io/crates/time/0.3.9 0.3.9 Apache-2.0 OR MIT
     https://crates.io/crates/tokio-io-timeout/1.0.1 1.0.1 Apache-2.0 OR MIT
     https://crates.io/crates/toml/0.5.2 0.5.2 Apache-2.0 OR MIT
+    https://crates.io/crates/unicode-ident/1.0.0 1.0.0 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-segmentation/1.2.0 1.2.0 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-width/0.1.4 0.1.4 Apache-2.0 OR MIT
     https://crates.io/crates/unicode-xid/0.2.0 0.2.0 Apache-2.0 OR MIT

--- a/src/logging/record.rs
+++ b/src/logging/record.rs
@@ -23,7 +23,7 @@ use crate::{
         TextLog, TraceContext, YamlLog,
     },
     trace::{
-        span::{AbstractSpan, Span},
+        span::{HandleSpanObject, Span},
         trace_context::TracingContext,
     },
 };

--- a/src/trace/span.rs
+++ b/src/trace/span.rs
@@ -31,8 +31,8 @@ use std::{
     sync::{Arc, Weak},
 };
 
-/// [AbstractSpan] contains methods handle [SpanObject].
-pub trait AbstractSpan {
+/// [HandleSpanObject] contains methods to handle [SpanObject].
+pub trait HandleSpanObject {
     /// Get immutable span object reference.
     fn span_object(&self) -> &SpanObject;
 
@@ -199,7 +199,7 @@ impl Drop for Span {
     }
 }
 
-impl AbstractSpan for Span {
+impl HandleSpanObject for Span {
     #[inline]
     fn span_object(&self) -> &SpanObject {
         self.obj.as_ref().unwrap()
@@ -249,7 +249,7 @@ impl Drop for AsyncSpan {
     }
 }
 
-impl AbstractSpan for AsyncSpan {
+impl HandleSpanObject for AsyncSpan {
     #[inline]
     fn span_object(&self) -> &SpanObject {
         self.obj.as_ref().unwrap()

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -28,7 +28,7 @@ use crate::{
     proto::v3::{RefType, SegmentObject, SegmentReference, SpanLayer, SpanObject, SpanType},
     trace::{
         propagation::context::PropagationContext,
-        span::{AbstractSpan, Span},
+        span::{HandleSpanObject, Span},
         tracer::{Tracer, WeakTracer},
     },
 };

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -24,7 +24,7 @@ use skywalking::{
         TextLog, TraceContext,
     },
     reporter::{CollectItem, Report},
-    trace::{span::AbstractSpan, tracer::Tracer},
+    trace::{span::HandleSpanObject, tracer::Tracer},
 };
 use std::{
     collections::LinkedList,

--- a/tests/trace_context.rs
+++ b/tests/trace_context.rs
@@ -23,7 +23,7 @@ use skywalking::{
     reporter::{print::PrintReporter, CollectItem, Report},
     trace::{
         propagation::{decoder::decode_propagation, encoder::encode_propagation},
-        span::AbstractSpan,
+        span::HandleSpanObject,
         tracer::Tracer,
     },
 };


### PR DESCRIPTION
Because Rust does not support inheritance, it is a bit strange to name the trait `AbstractSpan`, but it is more pleasing to name it as a verb.