### PR TITLE
Release SkyWalking Rust 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "skywalking"
-version = "0.9.0-dev"
+version = "0.9.0"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [package]
 name = "skywalking"
-version = "0.9.0-dev"
+version = "0.9.0"
 authors = ["Apache Software Foundation"]
 edition = "2024"
 description = "Apache SkyWalking Rust Agent"

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -212,7 +212,7 @@ The text of each license is the standard Apache 2.0 license.
     https://crates.io/crates/prost-derive/0.13.5 0.13.5 Apache-2.0
     https://crates.io/crates/prost-types/0.13.5 0.13.5 Apache-2.0
     https://crates.io/crates/protobuf-src/2.1.1+27.1 2.1.1+27.1 Apache-2.0
-    https://crates.io/crates/skywalking/0.9.0-dev 0.9.0-dev Apache-2.0
+    https://crates.io/crates/skywalking/0.9.0 0.9.0 Apache-2.0
     https://crates.io/crates/sync_wrapper/1.0.2 1.0.2 Apache-2.0
 
 ========================================================================

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -19,7 +19,7 @@
 name = "e2e"
 version = "0.0.0"
 authors = ["Apache Software Foundation"]
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 default-run = "e2e"

--- a/e2e/src/e2e_kafka.rs
+++ b/e2e/src/e2e_kafka.rs
@@ -18,12 +18,12 @@
 
 use prost::Message;
 use rdkafka::{
-    consumer::{Consumer, StreamConsumer},
     ClientConfig, Message as _,
+    consumer::{Consumer, StreamConsumer},
 };
 use skywalking::proto::v3::{
-    log_data_body::Content, meter_data::Metric, JsonLog, KeyStringValuePair, LogData, LogTags,
-    MeterData, RefType, SegmentObject, SpanLayer, SpanType,
+    JsonLog, KeyStringValuePair, LogData, LogTags, MeterData, RefType, SegmentObject, SpanLayer,
+    SpanType, log_data_body::Content, meter_data::Metric,
 };
 use std::time::Duration;
 use tokio::time::timeout;

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -17,10 +17,10 @@
 //
 use http_body_util::{Empty, Full};
 use hyper::{
+    Method, Request, Response, StatusCode,
     body::{Bytes, Incoming},
     client, server,
     service::service_fn,
-    Method, Request, Response, StatusCode,
 };
 use hyper_util::rt::TokioIo;
 use skywalking::{
@@ -33,9 +33,9 @@ use skywalking::{
         metricer::Metricer,
     },
     reporter::{
+        CollectItem, Report,
         grpc::GrpcReporter,
         kafka::{KafkaReportBuilder, KafkaReporter, RDKafkaClientConfig},
-        CollectItem, Report,
     },
     trace::{
         propagation::{


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` files for the `skywalking` and `e2e` packages. The most important changes are as follows:

Version and edition updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L27-R27): Updated the `skywalking` package version from `0.9.0-dev` to `0.9.0` and changed the edition to `2024`.
* [`e2e/Cargo.toml`](diffhunk://#diff-fd37c9d1c6ad4682b3739d37038806f9a253d0ef7a01a911df3d373e8988b7beL22-R22): Changed the edition of the `e2e` package from `2021` to `2024`.