### PR TITLE
chore(ci): Replace archived actions-rs actions

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -32,11 +32,9 @@ jobs:
           submodules: true
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Install and Run Tarpaulin
         run: |
           cargo install cargo-tarpaulin


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See https://github.com/apache/infrastructure-actions)
