### PR TITLE
Refactor Kafka client configuration to use a new ClientConfig struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,14 +226,14 @@ Make sure the feature `kafka-reporter` is enabled.
 #[cfg(feature = "kafka-reporter")]
 mod example {
     use skywalking::reporter::Report;
-    use skywalking::reporter::kafka::{KafkaReportBuilder, KafkaReporter, RDKafkaClientConfig};
+    use skywalking::reporter::kafka::{KafkaReportBuilder, KafkaReporter, ClientConfig};
 
     async fn do_something(reporter: &impl Report) {
         // ....
     }
 
     async fn foo() {
-        let mut client_config = RDKafkaClientConfig::new();
+        let mut client_config = ClientConfig::new();
         client_config
             .set("bootstrap.servers", "broker:9092")
             .set("message.timeout.ms", "6000");

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -35,7 +35,7 @@ use skywalking::{
     reporter::{
         CollectItem, Report,
         grpc::GrpcReporter,
-        kafka::{KafkaReportBuilder, KafkaReporter, RDKafkaClientConfig},
+        kafka::{ClientConfig, KafkaReportBuilder, KafkaReporter},
     },
     trace::{
         propagation::{
@@ -252,7 +252,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let reporter1 = GrpcReporter::connect("http://127.0.0.1:19876").await?;
     let handle1 = reporter1.reporting().await.spawn();
 
-    let mut client_config = RDKafkaClientConfig::new();
+    let mut client_config = ClientConfig::new();
     client_config
         .set("bootstrap.servers", "127.0.0.1:9092")
         .set("message.timeout.ms", "6000")


### PR DESCRIPTION
This pull request refactors the Kafka client configuration by introducing a new `ClientConfig` struct to replace the use of `RDKafkaClientConfig` directly. The changes improve code clarity, encapsulation, and configurability, particularly by adding support for a custom log level. The most important changes include replacing `RDKafkaClientConfig` with `ClientConfig` in multiple files, implementing the new `ClientConfig` struct, and updating the `KafkaReportBuilder` to use the new configuration.

### Refactoring Kafka Client Configuration:

* **Introduction of `ClientConfig` struct**:
  - Added a new `ClientConfig` struct in `src/reporter/kafka.rs`, encapsulating Kafka configuration parameters and log levels. It includes methods for setting parameters, setting log levels, and converting to `RDKafkaClientConfig`. [[1]](diffhunk://#diff-1821ca44408ec1f5c71006cbc28527e0c3d45e319ff811f40ec7c3ab9de97755R54-R136) [[2]](diffhunk://#diff-1821ca44408ec1f5c71006cbc28527e0c3d45e319ff811f40ec7c3ab9de97755L74-R167)

* **Replacement of `RDKafkaClientConfig` with `ClientConfig`**:
  - Updated references to `RDKafkaClientConfig` in `README.md` and `e2e/src/main.rs` to use the new `ClientConfig` struct. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R236) [[2]](diffhunk://#diff-7971767c2f99a1ba6318ec299954e70b2f305f3d0b9763c51a49f100eb150041L38-R38) [[3]](diffhunk://#diff-7971767c2f99a1ba6318ec299954e70b2f305f3d0b9763c51a49f100eb150041L255-R255)

### Updates to `KafkaReportBuilder`:

* **Refactored `KafkaReportBuilder` to use `ClientConfig`**:
  - Modified the `KafkaReportBuilder` struct and its methods to accept and work with `ClientConfig` instead of `RDKafkaClientConfig`. This includes changes to the `new`, `new_with_pc`, and `build` methods. [[1]](diffhunk://#diff-1821ca44408ec1f5c71006cbc28527e0c3d45e319ff811f40ec7c3ab9de97755L74-R167) [[2]](diffhunk://#diff-1821ca44408ec1f5c71006cbc28527e0c3d45e319ff811f40ec7c3ab9de97755L90-R176) [[3]](diffhunk://#diff-1821ca44408ec1f5c71006cbc28527e0c3d45e319ff811f40ec7c3ab9de97755L121-R207)

These changes enhance the maintainability and flexibility of the Kafka client configuration by abstracting the configuration details into a dedicated struct.